### PR TITLE
Adding an empty queue in the end handler

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -3,8 +3,17 @@ var choppedStream = require('../.')
 var fs = require('fs')
 var path = require('path')
 
-var numChunks = 0
-fs.createReadStream(path.join(__dirname, 'data/data.txt'))
+var numChunks = 0,
+	writeEnd = false, writeClose = false
+
+var readable = fs.createReadStream(path.join(__dirname, 'data/data.txt'));
+
+readable.on('close', function() {
+	assert(writeEnd, 'write stream should emit end');
+	assert(writeClose, 'write stream should emit close');
+})
+
+readable
   .pipe(choppedStream(1000))
   .on('data', function (chunk) {
     numChunks++
@@ -15,4 +24,10 @@ fs.createReadStream(path.join(__dirname, 'data/data.txt'))
       assert(chunk.length === 660,
              'Last chunk should be 660 bytes long')
     }
-  })
+	})
+	.on('end', function() {
+		writeEnd = true;
+	})
+	.on('close', function() {
+		writeClose = true;
+	})

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = function (chunkSize) {
 
   var end = function (data) {
     this.queue(chunk)
+    this.queue(null)
   }
 
   return through(write, end)


### PR DESCRIPTION
- This enabled events on through to be properly fired
- Without this, there's no way to detect events on the chunked-stream (close)
